### PR TITLE
fix Clock component and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite build & vite preview",
     "test": "jest --watchAll"
   },
   "dependencies": {

--- a/src/__tests__/components/Clock.test.jsx
+++ b/src/__tests__/components/Clock.test.jsx
@@ -1,17 +1,55 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import Clock from '../../components/Clock';
 
 describe('Clock component', () => {
-  const mockDate = new Date('2023-03-05T00:00:00');
-  const spy = jest.spyOn(global, 'Date').mockImplementationOnce(() => mockDate);
-
-  afterAll(() => {
-    spy.mockRestore();
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2023-03-05T00:00:00'));
   });
 
-  it('should render as expected', async () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should render as expected', () => {
     const { container } = render(<Clock updateEveryNSeconds={1} />);
     expect(container).toMatchSnapshot();
+  });
+
+  it('should update the time every second with prop: updateEveryNSeconds = 1', () => {
+    const tree = render(<Clock updateEveryNSeconds={1} />);
+    const timeElement = tree.getByTestId('time');
+    expect(timeElement).toHaveTextContent('12:00:00 a. m.');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(timeElement).toHaveTextContent('12:00:01 a. m.');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(timeElement).toHaveTextContent('12:00:02 a. m.');
+  });
+
+  it('should update the time every 2 seconds with prop: updateEveryNSeconds = 2', () => {
+    const tree = render(<Clock updateEveryNSeconds={2} />);
+    const timeElement = tree.getByTestId('time');
+    expect(timeElement).toHaveTextContent('12:00:00 a. m.');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(timeElement).toHaveTextContent('12:00:00 a. m.');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(timeElement).toHaveTextContent('12:00:02 a. m.');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(timeElement).toHaveTextContent('12:00:02 a. m.');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(timeElement).toHaveTextContent('12:00:04 a. m.');
   });
 });

--- a/src/__tests__/test-utils.js
+++ b/src/__tests__/test-utils.js
@@ -1,10 +1,9 @@
 import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+// eslint-disable-next-line import/prefer-default-export
 export const click = async (element) => {
   await act(async () => {
     await userEvent.click(element);
   });
 };
-
-export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -1,16 +1,10 @@
 import PropTypes from 'prop-types';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const Clock = ({ updateEveryNSeconds }) => {
   const [date, setDate] = useState(new Date());
-  const mounted = useRef(false);
 
   useEffect(() => {
-    if (!mounted.current) {
-      return () => {
-        mounted.current = true;
-      };
-    }
     const timerID = setInterval(() => setDate(new Date()), 1000 * updateEveryNSeconds);
     return () => clearInterval(timerID);
   }, [updateEveryNSeconds]);


### PR DESCRIPTION
There was a bug in the Clock component that stopped it from updating every second. This was caused by the implementation of the `useRef` hook that was intended to stop the `timerID` to be generated twice in every initial render.

I removed the hook and added some tests (that were failing before because of this bug)